### PR TITLE
Made app.js the bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Principles
 - Tests should not rely on data setup that happens external to the tests.
 - Tests should be able to be run in parallel.
 
+Installation
+------------
+Install with npm:
+    
+    $ npm install -g harvey
+
 Authoring
 ---------
 Harvey expects tests to be written in json, and the details are given below.  If you would prefer a UI for authoring your tests, check out the [Harvey Chrome App](https://github.com/tschwecke/harvey-chrome-app) which can be installed into Chrome from [here](https://chrome.google.com/webstore/detail/harvey/feajdnjnjfdjlmohkkemlanohcelmbga).
@@ -306,7 +312,7 @@ Config should be stored in a separate json document.  Here is an example:
 
 Running the Tests
 -----------------
-In order to run the tests you just need to kick off app.js with node.  By default it will look for a tests.json file in the same directory and will not load any config.  The exit code from the process equals the number of tests that failed, so it will exit with 0 if all tests passed.
+In order to run the tests you just need to execute `harvey` from the command line.  By default it will look for a tests.json file in the same directory and will not load any config.  The exit code from the process equals the number of tests that failed, so it will exit with 0 if all tests passed.
 
 Command Line Options
 --------------------

--- a/bin/harvey
+++ b/bin/harvey
@@ -1,9 +1,12 @@
-var commandLine = require('commander');
-var async = require('async');
-var SuiteBuilder = require('./lib/suiteBuilder.js');
-var reporterFactory = require('./lib/reporters/reporterFactory.js');
-var Status = require('./lib/util/status.js');
+#!/usr/bin/env node
+
 var _ = require('underscore');
+var async = require('async');
+var commandLine = require('commander');
+var path = require('path');
+var reporterFactory = require('../lib/reporters/reporterFactory.js');
+var SuiteBuilder = require('../lib/suiteBuilder.js');
+var Status = require('../lib/util/status.js');
 
 var options = getCommandLineArguments();
 var testData = getTestData(options);
@@ -86,7 +89,7 @@ function getTestData(options) {
 	var filename = options.testFile || 'tests.json';
 	
 	if(filename.substr(0, 1) !== '/' && filename.substr(0, 1) !== '.') {
-			filename = './' + filename;
+			filename = path.join(process.cwd(), filename);
 	}
 
 	try {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
 		"browserify": "2.x.x",
 		"minify": "0.2.x"
 	},
+	"main": "./index",
+	"bin": "./bin/harvey",
 	"engines": {
 		"node": ">=0.8.0"
 	},


### PR DESCRIPTION
Enables installing harvey globally. Local installations can use _node_modules/harvey/.bin/harvey_ as well.
