### PR TITLE
Add glob syntax support for -t option

### DIFF
--- a/bin/harvey
+++ b/bin/harvey
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var async = require('async');
 var commandLine = require('commander');
 var path = require('path');
+var glob = require('glob');
 var reporterFactory = require('../lib/reporters/reporterFactory.js');
 var Harvey = require('../index.js');
 var harvey = new Harvey();
@@ -29,8 +30,7 @@ try {
 
 	harvey.run(testData.tests, testData, config, function(error, suiteResult) {
 		if (error) {
-			console.log(color.red('Error: ' + error.message));
-			process.exit(1);
+			fail(error.message);
 		}
 
 		var stats = getTestStats(suiteResult);
@@ -54,8 +54,7 @@ try {
 		}
 	});
 } catch (error) {
-	console.log(color.red(error));
-	process.exit(1);
+	fail(error);
 }
 
 
@@ -72,31 +71,30 @@ function getCommandLineArguments() {
 
 	commandLine.testFile = commandLine.testFile || ((commandLine.args.length === 1) ? commandLine.args[0] : undefined);
 	if (!commandLine.testFile) {
-		console.error("Error: The path to the file containing the tests must be provided");
-		process.exit(1);
+		fail("The path to the file containing the tests must be provided");
 	}
 
 	return commandLine;
 }
 
-function loadTestData(filename, additonalFiles) {
+function loadTestData(filename, additionalFiles) {
+	var data = [];
 
-	var mainTestData = loadJson(filename);
-	if (!additonalFiles) {
-		return mainTestData;
+	glob.sync(filename).forEach(function(file) {
+		data.push(loadJson(file));
+	});
+
+	if (additionalFiles) {
+		additionalFiles.split(',').forEach(function(file) {
+			data.push(loadJson(file.trim()));
+		});
 	}
 
-	var args = [];
-	args.push(mainTestData);
-
-	var additionalFilesArray = additonalFiles.split(',');
-
-	for (var i = 0; i < additionalFilesArray.length; i++) {
-		// deal with whitespace...
-		additionalFilesArray[i] = additionalFilesArray[i].replace(/^\s*/, "").replace(/\s*$/, "");
-		args.push(loadJson(additionalFilesArray[i]));
+	if (!data.length) {
+		fail("No test files found");
 	}
-	return combiner.combineDatas.apply(null, args);
+
+	return combiner.combineDatas.apply(null, data);
 }
 
 function loadJson(filename) {
@@ -107,8 +105,7 @@ function loadJson(filename) {
 	try {
 		var data = require(filename);
 	} catch (e) {
-		console.log(color.red("Unable to load file '" + filename + "'; " + e));
-		process.exit(1);
+		fail("Unable to load file '" + filename + "': " + e);
 	}
 
 	return data;
@@ -197,4 +194,9 @@ function parseActionPaths(actionPathsString) {
 	}
 
 	return actions;
+}
+
+function fail(message) {
+	console.error(color.red('Error: ' + message));
+	process.exit(1);
 }

--- a/lib/util/combiner.js
+++ b/lib/util/combiner.js
@@ -11,7 +11,7 @@ module.exports = function() {
 		//callback = args.pop();
 
 		for (var x = 0; x < harveyParts.length; x++) {
-			var part = main[harveyParts[x]] || {};
+			var part = main[harveyParts[x]] || [];
 			for (var y = 0; y < args.length; y++) {
 				var additionalPart = args[y][harveyParts[x]] || {};
 				part = merge(part, additionalPart);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"blanket": "1.0.x",
 		"travis-cov": "0.2.x",
 		"joi": "0.3.x",
-		"z-schema": "1.x.x"
+		"z-schema": "1.x.x",
+    "glob": "~3.x.x"
 	},
 	"main": "./index",
 	"bin": "./bin/harvey",


### PR DESCRIPTION
Example:

```
harvey -t "spec/**/*.js"
```

Leaving this undocumented for now. The `-a` option still works, but it's less useful. In the future, it would be nice to specify a list of test files (with glob syntax support), perhaps as the last argument:

```
harvey [options] FILE...
harvey -c config/dev.json "test/foo/**/*.js" "test/bar/**/*.js"
```
