### PR TITLE
Add utf-8 meta tag to html template

### DIFF
--- a/lib/reporters/templates/layout
+++ b/lib/reporters/templates/layout
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="utf-8"/>
 
 		<title>Harvey Test Report</title>
 


### PR DESCRIPTION
Properly display non-ASCII characters when viewing the html file as a local file in the browser.
