### PR TITLE
Fix OAuth 1.0 parameter handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ update:
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha --recursive --reporter spec --timeout 3000 test
 
+test-debug:
+	@NODE_ENV=test node-debug -p 8081 ./node_modules/.bin/_mocha --recursive --reporter spec --timeout 3000 test
+
 test-cov:
 	@NODE_ENV=test ./node_modules/.bin/mocha --require blanket --recursive --timeout 3000 -R travis-cov test
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ myTemplates.json
 
 OAuth 1.0a Support
 ------------------
-If your services are protected by OAuth 1.0a, you can configure your Harvey tests to authenticate against those services.
+If your services are protected by [OAuth 1.0a](https://tools.ietf.org/html/rfc5849), you can configure your Harvey tests to authenticate against those services.
 
 The consumer key and consumer secret can be setup in your configuration file:
 
@@ -750,10 +750,10 @@ Then you add ```oauth``` to the request object:
 
 Harvey also implements the [OAuth Request Body Hash specification](https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html), automatically adding the ```oauth_body_hash``` protocol parameter to your requests.
 
-Harvey's OAuth implementation does not support the following parts of the [OAuth 1.0a spec](https://tools.ietf.org/html/rfc5849):
+Harvey's OAuth implementation does not support the following parts of the OAuth 1.0a spec:
 * Section 2
-** Redirection-Based Authorization (Harvey uses a pre-configured client consumer key and associated shared-secret)
-** oauth_token (resource owner authentication)
+  Redirection-Based Authorization (Harvey uses a pre-configured client consumer key and associated shared-secret)
+  oauth_token (resource owner authentication)
 * Entity-body parameters (3.4.1.3.1)
 * RSA-SHA1 (3.4.3) or PLAINTEXT (3.4.4) signature methods
 * Form-Encoded Body Parameter Transmission (3.5) 

--- a/README.md
+++ b/README.md
@@ -752,8 +752,8 @@ Harvey also implements the [OAuth Request Body Hash specification](https://oauth
 
 Harvey's OAuth implementation does not support the following parts of the OAuth 1.0a spec:
 * Section 2
-  Redirection-Based Authorization (Harvey uses a pre-configured client consumer key and associated shared-secret)
-  oauth_token (resource owner authentication)
+  * Redirection-Based Authorization (Harvey uses a pre-configured client consumer key and associated shared-secret)
+  * oauth_token (resource owner authentication)
 * Entity-body parameters (3.4.1.3.1)
 * RSA-SHA1 (3.4.3) or PLAINTEXT (3.4.4) signature methods
 * Form-Encoded Body Parameter Transmission (3.5) 

--- a/README.md
+++ b/README.md
@@ -718,7 +718,46 @@ myTemplates.json
 		}]
 	}
 
+OAuth 1.0a Support
+------------------
+If your services are protected by OAuth 1.0a, you can configure your Harvey tests to authenticate against those services.
 
+The consumer key and consumer secret can be setup in your configuration file:
+
+	{
+		"oauthConsumerKey": "exampleConsumerKey",
+		"oauthConsumerSecret": "somes3cret"
+	}
+
+Then you add ```oauth``` to the request object:
+
+	{
+		"id": "api_test",
+		"request": {
+			"method": "GET",
+			"protocol": "http",
+			"host": "www.foo.com",
+			"resource": "/api/bar",
+			"oauth": {
+				"consumerKey": "${oauthConsumerKey}",
+				"consumerSecret": "${oauthConsumerSecret}"
+			}
+		},
+		"expectedResponse": {
+			"statusCode": 200
+		}
+	}
+
+Harvey also implements the [OAuth Request Body Hash specification](https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html), automatically adding the ```oauth_body_hash``` protocol parameter to your requests.
+
+Harvey's OAuth implementation does not support the following parts of the [OAuth 1.0a spec](https://tools.ietf.org/html/rfc5849):
+* Section 2
+** Redirection-Based Authorization (Harvey uses a pre-configured client consumer key and associated shared-secret)
+** oauth_token (resource owner authentication)
+* Entity-body parameters (3.4.1.3.1)
+* RSA-SHA1 (3.4.3) or PLAINTEXT (3.4.4) signature methods
+* Form-Encoded Body Parameter Transmission (3.5) 
+* Request URI Parameter Transmission (3.5)
 
 Command Line Options
 --------------------

--- a/lib/testStepBuilder.js
+++ b/lib/testStepBuilder.js
@@ -273,7 +273,7 @@ module.exports = function() {
 			}
 
 
-			//EXPERIMENTAL - checkk if we need to add an oauth header to the request
+			// check if we need to add an oauth header to the request
 			if(request.oauth) {
 				require('./util/oauth.js').addAuthorization(retVal, request.oauth, variables);
 			}

--- a/lib/util/oauth.js
+++ b/lib/util/oauth.js
@@ -1,45 +1,174 @@
 var generateNonce = require('nonce')();
 var util = require('./util.js');
+var URL = require('url');
+var _ = require('underscore');
+var crypto = require('crypto');
 
-//EXPERIMENTAL - really ugly, hacky code to get something working.  Not fully OAUTH compliant
+/*
+ * Partial mplementation of OAuth 1.0a https://tools.ietf.org/html/rfc5849
+ * Known missing items:
+ *  - Section 2 - Redirection-Based Authorization (assumes a pre-configured client consumer key and shared-secret)
+ *              - oauth_token (resource owner authentication)
+ *  - Entity-body parameters (3.4.1.3.1)
+ *  - RSA-SHA1 (3.4.3) or PLAINTEXT (3.4.4) signature methods
+ *  - 3.5 Parameter Transmission - Authorization header is supported, but form-encoded body and request URI are not
+ */
+
 module.exports = {
 	"addAuthorization": function(request, oauthParams, variables) {
 		var method = request.method;
 		var url = request.uri;
-		var oauthConsumerKey = util.parseValue(oauthParams.consumerKey, variables);;
-		var oauthNonce = util.parseValue(oauthParams.nonce, variables) || generateNonce();
-		var oauthSignatureMethod = "HMAC-SHA1";
-		var oauthTimestamp = util.parseValue(oauthParams.timestamp, variables) || parseInt((new Date()).getTime() / 1000);
-		var oauthVersion = "1.0";
-		var oauthConsumerSecret = util.parseValue(oauthParams.consumerSecret, variables);;
+		var baseUrl = normalizeBaseUrl(url);
+		var oauthProtocolParams = {
+			'oauth_consumer_key': util.parseValue(oauthParams.consumerKey, variables),
+			'oauth_nonce': util.parseValue(oauthParams.nonce, variables) || generateNonce(),
+			'oauth_signature_method': "HMAC-SHA1",
+			'oauth_timestamp': util.parseValue(oauthParams.timestamp, variables) || parseInt((new Date()).getTime() / 1000),
+			'oauth_version': "1.0"
+		};
 
-		var signatureString = encodeURIComponent(method) + '&' +
-		                encodeURIComponent(url) + '&';
+		var oauthConsumerSecret = util.parseValue(oauthParams.consumerSecret, variables);
 
-		if(method == 'POST' || method == 'PUT') {
-			var sha1 = require('crypto').createHash('sha1');
-			sha1.update(request.body || '');
-			var oauthBodyHash = sha1.digest('base64');
-			signatureString += 'oauth_body_hash' + encodeURIComponent('=' + oauthBodyHash + '&')
-		}
+		var collectedParams = collectParams(request, oauthProtocolParams);
+		var normalizedParams = normalizeParams(collectedParams);
 
-		signatureString += 'oauth_consumer_key' + encodeURIComponent('=' + oauthConsumerKey + '&') +
-		                'oauth_nonce' + encodeURIComponent('=' + oauthNonce + '&') +
-		                'oauth_signature_method' + encodeURIComponent('=' + oauthSignatureMethod + '&') +
-		                'oauth_timestamp' + encodeURIComponent('=' + oauthTimestamp + '&') +
-		                'oauth_version' + encodeURIComponent('=' + oauthVersion);
+		var signatureString = encode(method) + '&' +
+		                      encode(baseUrl) + '&' +
+		                      encode(normalizedParams);
 
-		var hmac = require('crypto').createHmac('sha1', oauthConsumerSecret + '&');
+		var hmac = crypto.createHmac('sha1', oauthConsumerSecret + '&'); // no token but the '&' is still required
 		hmac.update(signatureString);
 		var signature = hmac.digest('base64');
 
-		var headerValue = 'OAuth realm="' + encodeURIComponent(url);
-		if(method == 'POST' || method == 'PUT') {
-			headerValue += '", oauth_body_hash="' + encodeURIComponent(oauthBodyHash);
-		}
-		headerValue +=  '", oauth_consumer_key="' + oauthConsumerKey + '", oauth_nonce="' + oauthNonce + '", oauth_signature="' + encodeURIComponent(signature) + '", oauth_signature_method="' + oauthSignatureMethod + '", oauth_timestamp="' + oauthTimestamp + '", oauth_version="' + oauthVersion + '"';
+		var headerValue = createAuthorizationHeader(baseUrl, collectedParams, signature)
 
 		request.headers['Authorization'] = headerValue;
 		request['_oauth'] = true;
 	}
+};
+
+normalizeBaseUrl = function(url) {
+	var parsedUrl = URL.parse(url);
+	var port = "";
+	var baseUrl = "";
+
+	if (parsedUrl.port) {
+		if ((parsedUrl.protocol == "http:" && parsedUrl.port != "80") ||
+			(parsedUrl.protocol == "https:" && parsedUrl.port != "443")) {
+			port = ":" + parsedUrl.port;
+		}
+	}
+
+	baseUrl = parsedUrl.protocol.toLowerCase() + "//" + parsedUrl.hostname.toLowerCase() + port + parsedUrl.pathname;
+	return baseUrl;
+};
+
+/*
+ * Gather decoded parameters (section 3.4.1.3.1)
+ */
+collectParams = function(request, oauthProtocolParams) {
+	// Add OAuth protocol parameters
+	var collectedParams = _.clone(oauthProtocolParams);
+
+	// Parse the url for the query string
+	// Cleans out '+' as described in 3.6
+	var parsedUrl = URL.parse(request.uri, true);
+	var queryParams = parsedUrl.query;
+
+	// Add url query parameters
+	for (var name in queryParams) {
+		value = queryParams[name];
+		collectedParams[name] = value;
+	}
+
+	// Note: Entity-body parameters not implemented
+
+	// oauth_body_hash extension
+	// https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html
+	if (request.method == 'POST' || request.method == 'PUT') {
+		var sha1 = crypto.createHash('sha1');
+		sha1.update(request.body || '');
+		var oauthBodyHash = sha1.digest('base64');
+		collectedParams['oauth_body_hash'] = oauthBodyHash;
+	}
+
+	return collectedParams;
+};
+
+/*
+ * Encode, sort, and concatenate parameters (section 3.4.1.3.2)
+ */
+normalizeParams = function(params) {
+	var encodedParams = [];
+	var normalizedParams = "";
+
+	// encode the names and values, and put them in an array for sorting
+	for (var name in params) {
+		if (params.hasOwnProperty(name)) {
+			// oauth parameter encoding is a little different than uri encoding
+			var reencodedName = encode(name);
+			var reencodedValue = encode(params[name]);
+			encodedParams.push([reencodedName, reencodedValue]);
+		}
+	}
+
+	// sort the params array
+	// if the keys are the same, sort by the values
+	encodedParams.sort(function(a, b) {
+		if (a[0] == b[0]) {
+			return a[1] < b[1] ? -1 : 1;
+		} else {
+			return a[0] < b[0] ? -1: 1;
+		}
+	});
+
+	// concatenate the params
+	for (var i = 0; i < encodedParams.length; i++) {
+		normalizedParams += encodedParams[i][0];
+		normalizedParams += '=';
+		normalizedParams += encodedParams[i][1];
+		if (i < encodedParams.length - 1) {
+			normalizedParams += '&';
+		}
+	}
+
+	return normalizedParams;
+};
+
+/*
+ * Create Authorization header (section 3.5.1)
+ */
+createAuthorizationHeader = function(realm, params, signature) {
+	var headerValue = 'OAuth realm="' + encode(realm);
+	
+	if (params['oauth_body_hash']) {
+		headerValue += '", oauth_body_hash="' + encode(params['oauth_body_hash']);
+	}
+	headerValue +=  '", oauth_consumer_key="'     + encode(params['oauth_consumer_key']) +
+	                '", oauth_nonce="'            + encode(params['oauth_nonce']) +
+	                '", oauth_signature="'        + encode(signature) +
+	                '", oauth_signature_method="' + encode(params['oauth_signature_method']) +
+	                '", oauth_timestamp="'        + encode(params['oauth_timestamp']) +
+	                '", oauth_version="'          + encode(params['oauth_version']) + '"';
+
+	return headerValue;
+}
+
+/*
+ * Encode (section 3.6)
+ *
+ * Mozilla recommends
+ *    return encodeURIComponent(data).replace(/[!'()*]/g, function(c) {
+ *        return '%' + c.charCodeAt(0).toString(16);
+ *    });
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+ *
+ * The implementation in this method more explicitly follows the spec.
+ */
+encode = function(data) {
+	if (!data) return data;
+	
+	return data.toString().replace(/[^A-Za-z0-9\-._~]/g, function(c) {
+		return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+	});
 };


### PR DESCRIPTION
Some OAuth tests were failing because query parameter handling wasn't implemented correctly. I built out the implementation for that part of the spec, and refactored the code to break it out into functions for readability and maintainability.