### PR TITLE
bump request to fix sslv3 issue. update nock pattern matching for oauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "memory-streams": "0.0.3",
     "nock": "0.x.x",
     "nonce": "^1.0.3",
-    "request": "2.48.0",
+    "request": "^2.64.0",
     "strip-json-comments": "1.x.x",
     "underscore": "1.x.x",
     "z-schema": "1.x.x"

--- a/test/testStepBuilder.test.js
+++ b/test/testStepBuilder.test.js
@@ -1094,7 +1094,7 @@ describe('testStepBuilder', function() {
 		      }
 		    })
 			// The request string format nock needs in order to match the resource above
-			httpMock.get("/oauth?a_filter=%20!%27()*-._~%20!%27()*-._~")
+			httpMock.get("/oauth?a_filter=%20%21%27%28%29%2A-._~%20%21%27%28%29%2A-._~")
 				.reply(200, "OK");
 
 			//Act


### PR DESCRIPTION
Update to latest request module to pull in fixes for SSLv3 vulns. Old request module on newer node (<=4.0.0) would bomb with this error when doing https:
```
> harvey -c test/integration/config.json test/integration/c2c.tests.json

(node) sys is deprecated. Use util instead.
_tls_common.js:23
      this.context.init(secureProtocol);
                   ^

Error: SSLv3 methods disabled
    at Error (native)
    at new SecureContext (_tls_common.js:23:20)
    at Object.createSecureContext (_tls_common.js:42:11)
    at Object.exports.connect (_tls_wrap.js:955:21)
    at Agent.createConnection (https.js:73:22)
    at Agent.createSocket (_http_agent.js:177:16)
    at Agent.addRequest (_http_agent.js:146:23)
    at new ClientRequest (_http_client.js:133:16)
    at Object.exports.request (http.js:31:10)
    at Object.exports.request (https.js:163:15)
```