### PR TITLE
support node module as well as json files for config

### DIFF
--- a/bin/harvey
+++ b/bin/harvey
@@ -2,6 +2,7 @@
 
 var _ = require('underscore');
 var pkg = require('../package.json');
+var path = require('path')
 var async = require('async');
 var commandLine = require('commander');
 var reporterFactory = require('../lib/reporters/reporterFactory.js');
@@ -9,7 +10,6 @@ var Harvey = require('../index.js');
 var harvey = new Harvey();
 var SuiteImporter = require('../lib/suiteImporter.js');
 var suiteImporter = new SuiteImporter();
-var loadJson = require('../lib/util/loadJson.js');
 var cliUtils = require('../lib/util/cli.js');
 var options = getCommandLineArguments();
 var timeout = cliUtils.parseTimeout(options.timeout);
@@ -24,7 +24,7 @@ try {
 }
 
 try {
-	config = (options.configFile) ? loadJson(options.configFile) : {};
+	config = (options.configFile) ? require(path.resolve(options.configFile)) : {};
 } catch(ex) {
 	cliUtils.fail(ex, options.debug);
 }


### PR DESCRIPTION
This PR allows the user to specify either .json file (currently supported) or a node module that returns a config object (new feature).

The benefit here is that a user can utilize dynamic configuration information based on env, etc.