### PR TITLE
Makes harvey-transformer actually produce output

### DIFF
--- a/bin/harvey-transformer
+++ b/bin/harvey-transformer
@@ -22,7 +22,14 @@ try {
 }
 
 if (options.jsonResults) {
-	loadJson(null, options.jsonResults);
+  var overallResults;
+  try {
+    overallResults = loadJson(options.jsonResults);
+  } catch (err) {
+    processJson(err);
+    return;
+  }
+  processJson(null, overallResults);
 } else {
 	stdin(processJson);
 }


### PR DESCRIPTION
In the current version of harvey, the `harvey-transform` command doesn't actually produce any output due to a missing call to `processJson`

## Current

```
harvey-transform -j path/to/file.json -r console
# no output here
```

## Fixed

> Example schema.test.json output contained in file.json

```
harvey-transform -j path/to/file.json -r console
  ■ test/integration/schema.test.json
    ✓ schema

    Time elapsed: 414 ms
    1 tests complete, 0 failures.

  Overall time elapsed: 433 ms
  1 tests complete, 0 failures.
```

### Invalid json in file

This change also prints appropriately formatted error output when input file contains invalid json

```
harvey-transform -j path/to/invalid.json -r console
Unable to load file "path/to/invalid.json": SyntaxError: Unexpected token o in JSON at position 1
```

### Missing json file

This change also prints appropriately formatted error output when input file cannot be found

```
harvey-transform -j path/to/missing.json -r console
Unable to find file "path/to/missing.json"
```
